### PR TITLE
Add `/blog` suffix to blog base URL in RSS generator

### DIFF
--- a/scripts/build-rss.js
+++ b/scripts/build-rss.js
@@ -25,7 +25,7 @@ function rssFeed(type, title, desc, outputPath) {
     return i2Date - i1Date;
   });
 
-  const base = 'https://json-schema.org';
+  const base = 'https://json-schema.org/blog';
   const tracking = '?utm_source=rss';
 
   const feed = {};


### PR DESCRIPTION
Currently, [the RSS feed](https://json-schema.org/blog/rss.xml) is generated with all links broken because of missing `/blog` suffix in `base` variable.

I have marked all broken links:

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
  <channel>
    <title>JSON Schema Blog RSS Feed</title>
    <link>https://json-schema.org/rss.xml</link> <!-- 👈 -->
    <atom:link rel="self" href="https://json-schema.org/rss.xml" type="application/rss+xml"/> <!-- 👈 -->
    <description>JSON Schema Blog</description>
    <language>en-gb</language>
    <copyright>Made with :love: by the JSON Schema team.</copyright>
    <pubDate>Thu, 01 Sep 2022 09:34:32 GMT</pubDate>
    <generator>next.js</generator>
    <item>
      <title>Using Dynamic References to Support Generic Types</title>
      <description>A step in the right direction for modelling data with JSON Schema</description>
      <link>https://json-schema.org/posts/dynamicref-and-generics?utm_source=rss</link> <!-- 👈 -->
      <category>blog</category>
      <guid isPermaLink="true">https://json-schema.org/posts/dynamicref-and-generics?utm_source=rss</guid> <!-- 👈 -->
      <pubDate>Wed, 31 Aug 2022 00:00:00 GMT</pubDate>
      <enclosure url="https://json-schema.org/img/posts/2022/dynamicref-and-generics/cover.webp" length="15026" type="image/webp"/> <!-- 👈 -->
    </item>
    <!-- ... -->
  </channel>
</rss>
```